### PR TITLE
more verbose logging of transcription problems with invalid allophones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Lexicon compiler plugin for MaryTTS
 ### Changed
 
 - Build with Gradle v4.5
+- More verbose logging of transcription problems
 
 [v0.1.1] - 2017-02-24
 ---------------------

--- a/src/main/groovy/de/dfki/mary/lexicon/LexiconCompile.groovy
+++ b/src/main/groovy/de/dfki/mary/lexicon/LexiconCompile.groovy
@@ -53,6 +53,11 @@ class LexiconCompile extends DefaultTask {
                     // store valid transcription
                     lexicon[lemma] = transcription
                 } else {
+                    try {
+                        allophoneSet.splitIntoAllophoneList(transcription, false)
+                    } catch (all) {
+                        project.logger.info all.message
+                    }
                     project.logger.warn "Invalid transcription for '$lemma': [$transcription]"
                 }
             }


### PR DESCRIPTION
duplicates a method call in AllophoneSet#checkAllophoneSyntax, but there, the exception is silently ignored -- this rethrows it and logs the message